### PR TITLE
support multiple dev guild id in the config

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,7 +19,7 @@ import { getEnv } from './core/utils/env';
         IntentsBitField.Flags.DirectMessages,
         IntentsBitField.Flags.MessageContent,
       ],
-      development: [getEnv('DISCORD_DEVELOPMENT_GUILD_ID')],
+      development: getEnv('DISCORD_DEVELOPMENT_GUILD_IDs'),
     }),
     AppCommandsModule,
   ],

--- a/backend/src/core/utils/env.ts
+++ b/backend/src/core/utils/env.ts
@@ -2,7 +2,12 @@ import { z } from 'zod';
 
 export const environmentSchema = z.object({
   DISCORD_TOKEN: z.string().min(1),
-  DISCORD_DEVELOPMENT_GUILD_ID: z.string().min(1),
+  DISCORD_DEVELOPMENT_GUILD_IDs: z
+    .string()
+    .min(1)
+    .transform((val) => {
+      return val.split(',').map((id) => id.trim());
+    }),
   POSTGRES_DB_USER: z.string().min(1),
   POSTGRES_DB_NAME: z.string().min(1),
   POSTGRES_PASSWORD: z.string().min(1),


### PR DESCRIPTION
# What does this PR
- Allow env files to have multiple development guild IDs.