### PR TITLE
add security to not notify trakers who doesn't have access to the channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ This will rebuild and run the containers.
 - `.github` Github Actions CI/CD
 
 ## Roadmap
-- Add security, to the existing commands, to not send connection notification if the tracked user is in a channel not accessible by the tracker.
 - Add the command `/log voice-connection` to display the last voice connection in the guild:
   - Specifications:
     - Exclude channel that the invoker don't see.

--- a/backend/src/application/abstractions/communication-platform/ICommunicationPlatform.ts
+++ b/backend/src/application/abstractions/communication-platform/ICommunicationPlatform.ts
@@ -14,4 +14,9 @@ export interface ICommunicationPlatform {
     userId: Snowflake,
   ): Promise<boolean>;
   getUsersByRole(guildId: Snowflake, roleId: Snowflake): Promise<Snowflake[]>;
+  hasPermissionToAccessTheVoiceChannel(
+    guildId: Snowflake,
+    channelId: Snowflake,
+    userId: Snowflake,
+  ): Promise<boolean>;
 }

--- a/backend/src/application/voice-channel-connection-tracking/notify-connection-of-tracked-user/NotifyConnectionOfTrackedUserCommandHandler.ts
+++ b/backend/src/application/voice-channel-connection-tracking/notify-connection-of-tracked-user/NotifyConnectionOfTrackedUserCommandHandler.ts
@@ -59,6 +59,20 @@ export class NotifyConnectionOfTrackedUserCommandHandler {
         continue;
       }
 
+      const hasAccessToTheVoiceChannel =
+        await this.communicationPlatform.hasPermissionToAccessTheVoiceChannel(
+          command.guildId,
+          command.voiceChannelId,
+          order.trackerGuildMemberId,
+        );
+
+      if (!hasAccessToTheVoiceChannel) {
+        this.logger.log(
+          `User ${order.trackerGuildMemberId} does not have permission to access the voice channel ${command.voiceChannelId} in guild ${command.guildId}. Skipping notification.`,
+        );
+        continue;
+      }
+
       const isInVoiceChannel =
         await this.communicationPlatform.isInVoiceChannel(
           command.guildId,

--- a/backend/src/application/voice-channel-connection-tracking/notify-connection-of-user-with-tracked-role/NotifyConnectionOfUserWithTrackedRoleCommandHandler.spec.ts
+++ b/backend/src/application/voice-channel-connection-tracking/notify-connection-of-user-with-tracked-role/NotifyConnectionOfUserWithTrackedRoleCommandHandler.spec.ts
@@ -28,6 +28,7 @@ describe('NotifyConnectionOfUserWithTrackedRoleCommandHandler', () => {
   let communicationPlatformIsInVoiceChannelSpy: jest.SpyInstance;
   let communicationPlatformIsUserExistInGuildSpy: jest.SpyInstance;
   let communicationPlatformSendMessageToUserSpy: jest.SpyInstance;
+  let communicationPlatformHasPermissionToAccessTheVoiceChannelSpy: jest.SpyInstance;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -81,6 +82,11 @@ describe('NotifyConnectionOfUserWithTrackedRoleCommandHandler', () => {
     communicationPlatformSendMessageToUserSpy.mockResolvedValue(() =>
       Promise.resolve(),
     );
+
+    communicationPlatformHasPermissionToAccessTheVoiceChannelSpy = jest.spyOn(
+      communicationPlatform,
+      'hasPermissionToAccessTheVoiceChannel',
+    );
   });
 
   afterEach(() => {
@@ -123,6 +129,9 @@ describe('NotifyConnectionOfUserWithTrackedRoleCommandHandler', () => {
 
       communicationPlatformIsInVoiceChannelSpy.mockResolvedValue(false);
       communicationPlatformIsUserExistInGuildSpy.mockResolvedValue(true);
+      communicationPlatformHasPermissionToAccessTheVoiceChannelSpy.mockResolvedValue(
+        true,
+      );
 
       await commandHandler.handle(command);
 
@@ -152,6 +161,9 @@ describe('NotifyConnectionOfUserWithTrackedRoleCommandHandler', () => {
 
       communicationPlatformIsInVoiceChannelSpy.mockResolvedValue(true);
       communicationPlatformIsUserExistInGuildSpy.mockResolvedValue(true);
+      communicationPlatformHasPermissionToAccessTheVoiceChannelSpy.mockResolvedValue(
+        true,
+      );
 
       await commandHandler.handle(command);
 
@@ -177,6 +189,9 @@ describe('NotifyConnectionOfUserWithTrackedRoleCommandHandler', () => {
 
       communicationPlatformIsInVoiceChannelSpy.mockResolvedValue(false);
       communicationPlatformIsUserExistInGuildSpy.mockResolvedValue(true);
+      communicationPlatformHasPermissionToAccessTheVoiceChannelSpy.mockResolvedValue(
+        true,
+      );
 
       await commandHandler.handle(command);
 
@@ -197,6 +212,9 @@ describe('NotifyConnectionOfUserWithTrackedRoleCommandHandler', () => {
 
       communicationPlatformIsInVoiceChannelSpy.mockResolvedValue(false);
       communicationPlatformIsUserExistInGuildSpy.mockResolvedValue(false);
+      communicationPlatformHasPermissionToAccessTheVoiceChannelSpy.mockResolvedValue(
+        true,
+      );
 
       await commandHandler.handle(command);
 
@@ -222,6 +240,9 @@ describe('NotifyConnectionOfUserWithTrackedRoleCommandHandler', () => {
 
       communicationPlatformIsInVoiceChannelSpy.mockResolvedValue(true);
       communicationPlatformIsUserExistInGuildSpy.mockResolvedValue(true);
+      communicationPlatformHasPermissionToAccessTheVoiceChannelSpy.mockResolvedValue(
+        true,
+      );
 
       await commandHandler.handle(command);
 
@@ -249,6 +270,29 @@ describe('NotifyConnectionOfUserWithTrackedRoleCommandHandler', () => {
       expect(
         roleBasedVCCTRepositoryFindAllByTrackedTrackedRolesSpy,
       ).toHaveBeenCalledWith(guildId, command.guildMemberRoleIds);
+      expect(communicationPlatformSendMessageToUserSpy).not.toHaveBeenCalled();
+    });
+
+    it(`Should not notify users if they do not have permission to access the voice channel`, async () => {
+      const command: NotifyConnectionOfUserWithTrackedRoleCommand = {
+        guildId,
+        guildMemberId,
+        voiceChannelId,
+        guildMemberRoleIds,
+        alreadyNotifiedGuildMemberIds,
+      };
+
+      communicationPlatformIsInVoiceChannelSpy.mockResolvedValue(false);
+      communicationPlatformIsUserExistInGuildSpy.mockResolvedValue(true);
+      communicationPlatformHasPermissionToAccessTheVoiceChannelSpy.mockResolvedValue(
+        false,
+      );
+
+      await commandHandler.handle(command);
+
+      expect(
+        roleBasedVCCTRepositoryFindAllByTrackedTrackedRolesSpy,
+      ).toHaveBeenCalledWith(guildId, guildMemberRoleIds);
       expect(communicationPlatformSendMessageToUserSpy).not.toHaveBeenCalled();
     });
   });

--- a/backend/src/application/voice-channel-connection-tracking/notify-connection-of-user-with-tracked-role/NotifyConnectionOfUserWithTrackedRoleCommandHandler.ts
+++ b/backend/src/application/voice-channel-connection-tracking/notify-connection-of-user-with-tracked-role/NotifyConnectionOfUserWithTrackedRoleCommandHandler.ts
@@ -71,6 +71,20 @@ export class NotifyConnectionOfUserWithTrackedRoleCommandHandler {
         continue;
       }
 
+      const hasAccessToTheVoiceChannel =
+        await this.communicationPlatform.hasPermissionToAccessTheVoiceChannel(
+          command.guildId,
+          command.voiceChannelId,
+          guildMemberIdToNotify,
+        );
+
+      if (!hasAccessToTheVoiceChannel) {
+        this.logger.log(
+          `User ${guildMemberIdToNotify} does not have permission to access the voice channel ${command.voiceChannelId} in guild ${command.guildId}. Skipping notification.`,
+        );
+        continue;
+      }
+
       const isInVoiceChannel =
         await this.communicationPlatform.isInVoiceChannel(
           command.guildId,

--- a/backend/src/infrastructure/communication-platform/DiscordCommunicationPlatform.ts
+++ b/backend/src/infrastructure/communication-platform/DiscordCommunicationPlatform.ts
@@ -5,6 +5,7 @@ import {
   DiscordAPIError,
   Guild,
   GuildMember,
+  PermissionFlagsBits,
   Role,
   Snowflake,
   User,
@@ -179,6 +180,34 @@ export class DiscordCommunicationPlatform implements ICommunicationPlatform {
 
     console.log(`The role ${role.name} has ${role.members.size} members.`);
     return role.members.map((member) => member.id);
+  }
+
+  async hasPermissionToAccessTheVoiceChannel(
+    guildId: Snowflake,
+    channelId: Snowflake,
+    userId: Snowflake,
+  ): Promise<boolean> {
+    const guild = await this.fetchGuild(guildId);
+    if (!guild) {
+      return false; // Guild not found
+    }
+
+    const voiceChannel = await this.fetchVoiceChannelFromGuild(
+      guild,
+      channelId,
+    );
+    if (!voiceChannel) {
+      return false; // Voice channel not found
+    }
+
+    const member = await this.fetchGuildMembersFromGuild(guild, userId);
+    if (!member) {
+      return false; // Member not found
+    }
+
+    return member
+      .permissionsIn(voiceChannel)
+      .has(PermissionFlagsBits.ViewChannel | PermissionFlagsBits.Connect);
   }
 }
 


### PR DESCRIPTION
# What does this PR ?

- Add a check to skip the tracker and not notify him if he doesn't have the permission to see and connect to the voice channel the tracked has connected in.