### PR TITLE
fix tracking display command to only display users tracked directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ This will rebuild and run the containers.
 - `.github` Github Actions CI/CD
 
 ## Roadmap
-- Rework `/tracking display` command to only display user tracked directly.
 - Add the command `/log voice-connection` to display the last voice connection in the guild:
   - Specifications:
     - Exclude channel that the invoker don't see.

--- a/backend/src/application/voice-channel-connection-tracking/get-user-tracking-connection-orders/GetUserTrackingConnectionOrdersQueryHandler.ts
+++ b/backend/src/application/voice-channel-connection-tracking/get-user-tracking-connection-orders/GetUserTrackingConnectionOrdersQueryHandler.ts
@@ -133,7 +133,7 @@ export class GetUserTrackingConnectionOrdersQueryHandler {
         trackedRoleCount: trackedRoleInformation.length,
         totalTrackedUsers: alltrackedUsers.size,
         totalTrackingOrders: totalTrackingOrders,
-        trackedUsers: Array.from(alltrackedUsers),
+        trackedUsers: Array.from(trackedUsers),
         trackedRoles: trackedRoleInformation,
       },
     );


### PR DESCRIPTION
# What does this PR ?
- It fix the `/tracking display` command to only display users tracked directly by the sender or the mentionned user.